### PR TITLE
Profile page interaction bugfix

### DIFF
--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -13,9 +13,9 @@ function Profile() {
   const [favouriteRecipes, setFavouriteRecipes] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
   let { userData, setUserData } = useUserData();
+  const [count, setCount] = useState(0);
 
   const menuRef = useRef(null);
-
   useEffect(() => {
     getUserData(setUserData);
   }, [setUserData]);
@@ -26,14 +26,22 @@ function Profile() {
       setOwnRecipes(r);
     });
 
-    getAllRecipes().then((r) => {
-      setRecipes(r);
-    });
-  }, [userData]);
+    if (count < 2) {
+      getAllRecipes().then((r) => {
+        setRecipes(r);
+        console.log("test");
+      });
+      setCount((c) => c + 1);
+    } else {
+      setCount(0);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipes, userData]);
 
   useEffect(() => {
     setFavouriteRecipes(
-      recipes.filter((recipe) => userData.user.favoriteRecipes.includes(recipe._id))
+      recipes.filter((recipe) => userData?.user?.favoriteRecipes.includes(recipe._id))
     );
   }, [recipes, userData]);
 

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -29,7 +29,6 @@ function Profile() {
     if (count < 2) {
       getAllRecipes().then((r) => {
         setRecipes(r);
-        console.log("test");
       });
       setCount((c) => c + 1);
     } else {


### PR DESCRIPTION
Ich weiß beim besten Willen nicht was hier los ist. 

Wenn man like/dislike in der profile page nutzt werden die nicht dynamisch geupdatet. Im Recipe Browser funktioniert das, obwohl beide ja einfach die RecipeTileList benutzen, in der ich diese Funktionalität eingebaut habe. 

Ich meine damit die Like/Dislike counter wenn man etwas daran ändert.

Als Lösung hab ich einfach Recipes als dependency bei dem UseEffect benutzt, damit die Recipes neu gesetzt werden, aber das führt dann zu einem infinite Loop weil ja setRecipes ausgeführt wird. Das dynamische updaten funktioniert dann, was ich nicht verstehe weil es eigentlich mit dem setFavouriteRecipes was übergeben wird funktionieren sollte.

Um die infinite Loop zu umgehen habe ich deshalb richtig dumm einfach einen Counter gemacht um zu checken wie oft das useEffect aufgerufen wird. Wenn es aufgerufen wird kommt es ja garantiert zum Loop, deshalb zähle ich einfach 2 mal mit und stoppe das dann.

Man kann es auch testen alles funktioniert und wenn man beim counter < 1 anstatt < 2 macht sieht man auch sofort, dass es nicht mehr funktioniert.

Müssen wir uns später anschauen...